### PR TITLE
Allow to serve static files as response to POST

### DIFF
--- a/lib/ecstatic.js
+++ b/lib/ecstatic.js
@@ -221,7 +221,7 @@ module.exports = function createMiddleware(_dir, _options) {
       return;
     }
 
-    if (req.method && (req.method !== 'GET' && req.method !== 'HEAD')) {
+    if (req.method && (req.method !== 'GET' && req.method !== 'HEAD' && req.method !== 'POST')) {
       status[405](res, next);
       return;
     }


### PR DESCRIPTION
Sometimes it is useful to serve static answers to POST requests. However ecstatic rejects all requests except GET or HEAD. This small patch fixes it.